### PR TITLE
UUID validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: uuid
 Version: 0.1-2
-Title: Tools for generating and handling of UUIDs
+Title: Tools for Generating and Handling of UUIDs
 Author: Simon Urbanek <Simon.Urbanek@r-project.org> (R package), Theodore Ts'o <tytso@thunk.org> (libuuid)
 Maintainer: Simon Urbanek <Simon.Urbanek@r-project.org>
 Depends: R (>= 2.9.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,6 +4,6 @@ Title: Tools for Generating and Handling of UUIDs
 Author: Simon Urbanek <Simon.Urbanek@r-project.org> (R package), Theodore Ts'o <tytso@thunk.org> (libuuid)
 Maintainer: Simon Urbanek <Simon.Urbanek@r-project.org>
 Depends: R (>= 2.9.0)
-Description: Tools for generating and handling of UUIDs (Universally Unique Identifiers).
+Description: Tools for Generating and Handling of UUIDs (Universally Unique Identifiers).
 License: MIT + file LICENSE
 URL: http://www.rforge.net/uuid

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: uuid
-Version: 0.1-2
+Version: 0.2
 Title: Tools for Generating and Handling of UUIDs
 Author: Simon Urbanek <Simon.Urbanek@r-project.org> (R package), Theodore Ts'o <tytso@thunk.org> (libuuid)
 Maintainer: Simon Urbanek <Simon.Urbanek@r-project.org>

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,2 +1,4 @@
 useDynLib(uuid, UUID_gen)
+useDynLib(uuid, UUID_validate)
 export(UUIDgenerate)
+export(UUIDvalidate)

--- a/R/uuid.R
+++ b/R/uuid.R
@@ -1,1 +1,15 @@
 UUIDgenerate <- function(use.time = NA) .Call(UUID_gen, use.time)
+
+##--------------------------------------------------------------------------------
+## Vectorized.
+## Returns a length(uuid) logical vector.
+## If is.na(uuid[i]), then UUIDvalidate(uuid)[i] == NA.
+##
+## Validation is done via libuuid's uuid_parse, and is thus much faster than using regexs.
+##
+## Does **not** validate _type_ of UUID (i.e. doesn't distingush between DCE, MD5, MAC access, etc. types).
+##--------------------------------------------------------------------------------
+UUIDvalidate <- function(uuid) {
+    stopifnot(is.character(uuid))
+    .Call(UUID_validate, uuid)
+}

--- a/R/uuid.R
+++ b/R/uuid.R
@@ -1,14 +1,5 @@
 UUIDgenerate <- function(use.time = NA) .Call(UUID_gen, use.time)
 
-##--------------------------------------------------------------------------------
-## Vectorized.
-## Returns a length(uuid) logical vector.
-## If is.na(uuid[i]), then UUIDvalidate(uuid)[i] == NA.
-##
-## Validation is done via libuuid's uuid_parse, and is thus much faster than using regexs.
-##
-## Does **not** validate _type_ of UUID (i.e. doesn't distingush between DCE, MD5, MAC access, etc. types).
-##--------------------------------------------------------------------------------
 UUIDvalidate <- function(uuid) {
     stopifnot(is.character(uuid))
     .Call(UUID_validate, uuid)

--- a/man/UUIDvalidate.Rd
+++ b/man/UUIDvalidate.Rd
@@ -1,0 +1,38 @@
+\encoding{UTF-8}
+\name{UUIDvalidate}
+\alias{UUIDvalidate}
+\title{
+  Validate UUIDs
+}
+\description{
+  \code{UUIDvalidate} validates Universally Unique Identifier strings.
+}
+\usage{
+UUIDvalidate(uuid)
+}
+\arguments{
+  \item{uuid}{character vector of UUID strings.}
+}
+\details{
+  Rather than using regular expressions, this function uses \code{libuuid}'s
+  \code{uuid_parse} function for efficiency.
+
+  NA strings in `uuid` lead to NAs in the output vector.
+}
+\value{
+  Logical vector, possibly containing NA values (see details).
+}
+%\references{
+%}
+\author{
+  Murat Taşan, using libuuid by Theodore Ts'o.
+}
+%\note{
+%}
+\examples{
+uuids <- sapply(1:10, UUIDgenerate)
+uuids[3] <- NA
+uuids[6] <- "foo"
+UUIDvalidate(uuids)
+UUIDvalidate(character(0))
+}

--- a/man/UUIDvalidate.Rd
+++ b/man/UUIDvalidate.Rd
@@ -15,7 +15,8 @@ UUIDvalidate(uuid)
 }
 \details{
   Rather than using regular expressions, this function uses \code{libuuid}'s
-  \code{uuid_parse} function for efficiency.
+  \code{uuid_parse} function for efficiency (and provides a ~5X speed
+  boost vs \code{grepl}).
 
   NA strings in `uuid` lead to NAs in the output vector.
 }
@@ -34,5 +35,9 @@ uuids <- sapply(1:10, UUIDgenerate)
 uuids[3] <- NA
 uuids[6] <- "foo"
 UUIDvalidate(uuids)
-UUIDvalidate(character(0))
+UUIDvalidate(toupper(uuids)) ## works with upper-case, too.
+
+uuids <- sapply(1:1e5, UUIDgenerate) ## generate 100,000 UUIDs for speed test
+system.time(UUIDvalidate(uuids)) ## ~0.047s on a test laptop
+system.time(grepl("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", uuids)) ## ~0.27s on same test laptop
 }

--- a/src/R.c
+++ b/src/R.c
@@ -16,3 +16,24 @@ SEXP UUID_gen(SEXP sTime) {
     return mkString(c);
 }
 
+
+SEXP UUID_validate(SEXP uuids) {
+  SEXP out = PROTECT(allocVector(LGLSXP, length(uuids))); // allocate return value (out).
+  uuid_t uuid_bin;
+
+  for(int i = 0; i < length(uuids); i++) {
+    if(STRING_ELT(uuids, i) == NA_STRING) {
+      LOGICAL(out)[i] = NA_LOGICAL;
+      continue;
+    }
+
+    // uuid_parse returns 0 on success, -1 on failure.
+    // adding 1 will coerce to C bool, but the below is more defensive.
+    // 0 is success, _anything_ else is failure (to future-proof against possible libuuid changes to error return values).
+    int x = uuid_parse(CHAR(STRING_ELT(uuids, i)), uuid_bin);
+    LOGICAL(out)[i] = x == 0 ? 1 : 0;
+  } // closes for-loop
+  
+  UNPROTECT(1);
+  return out;
+}


### PR DESCRIPTION
Hi, I've been using `uuid` to create UUIDs in R, and it's great.
But, I also have to verify UUIDs (as part of some data cleaning), and ended up using libuuid's `uuid_parse` function for a substantial speed-boost over relying on regexs.
I figured it'd be nice to include this extra functionality in the `uuid` package (without me forking the package and uploading a totally separate, but very similar package to CRAN... there's enough fragmentation of nearly-identical packages already :-)

The code additions/changes are fairly straight-forward, and I've included an example in the UUIDvalidate man page to demonstrate the speedup (over using `grepl`).

I'm also happy to help maintain the package if there are other ideas/features/etc. that you have, but are otherwise too busy to implement.

Cheers,

-Murat
