### PR TITLE
Fixes a few R CMD check issues

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -f config.* src/Makevars src/config.h

--- a/src/R.c
+++ b/src/R.c
@@ -16,3 +16,12 @@ SEXP UUID_gen(SEXP sTime) {
     return mkString(c);
 }
 
+static const R_CallMethodDef uuid_entries[] = {
+  {"UUID_gen", (DL_FUNC) &UUID_gen, 1},
+  {NULL, NULL, 0}
+};
+
+void R_init_uuid(DllInfo *dll) {
+  R_registerRoutines(dll, NULL, uuid_entries, NULL, NULL);
+  R_useDynamicSymbols(dll, FALSE);
+}


### PR DESCRIPTION
These two commits fix small issues encountered when running `R CMD check` on the package. The first addresses the following:

> File ‘uuid/libs/uuid.so’: Found no calls to: ‘R_registerRoutines’, ‘R_useDynamicSymbols’
>
> It is good practice to register native routines and to disable symbol search.

by adding the appropriate calls to these functions. This should actually improve the loading speed of the package, as well.

The second silences issues with spuriously included build files by adding a `cleanup` script (as per [R's suggestion](https://cran.r-project.org/doc/manuals/R-exts.html#Configure-and-cleanup)).