### PR TITLE
Fix linking on windows/llvm/arm64

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,1 +1,2 @@
 PKG_CPPFLAGS=-include config.h -Iwin32
+PKG_LIBS=-lpthread


### PR DESCRIPTION
Right now we see:

```
clang -shared -s -static-libgcc -o uuid.dll tmp.def R.o Ruuid.o clear.o compare.o copy.o gen_uuid.o isnull.o md5.o pack.o parse.o rand.o randutils.o sha1.o unpack.o unparse.o -LC:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/lib -LC:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/lib -LC:/PROGRA~1/R/R-devel/bin -lR
ld.lld: error: undefined symbol: nanosleep
>>> referenced by randutils.o:(xusleep)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
no DLL was created
ERROR: compilation failed for package 'uuid'
```

In llvm we need to explicitly link pthread to use nanosleep.